### PR TITLE
Add: Show frequently used emojis based on usage.

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -7,6 +7,11 @@
 	font-display: swap;
 }
 
+.EA-preferred-suggestion-item {
+	display: inline-block;
+	padding: 6px;
+}
+
 .EA-suggester-container {
   display: flex;
   place-content: space-between;


### PR DESCRIPTION
Frequently used emojis are following the conditions to keep it lastest.
1. A new entry is inserted at the first of the list of emojis.
2. When an entry is updated, it is moved to the first of the list of emojis.
3. Emojis are shown by its use count.
4. The list of emojis remove entries over its limit configured by user regardless of its count.

Major updates

styles.css
   add .EA-preferred-suggestion-item to allow horizontally arranged emojis.

main.ts
   update ExtGEmoji's matchedBy to allow 'preference'. add ExtGemojiSetting to save ExtGEmoji with usage count. EmojiShortcodesPlugin
   add updatePreference() after selecting icon in suggestions. EmojiSuggester
   update getSuggestions to insert preferred emojis at the start of suggestions. update renderSuggestion to show perferred emojis.

settings.ts
   add settings for perferred emojis.
   
Considerations
   Icons can be navigated through arrow down, and arrow right, left still moves cursor in text. Review if it will fine for user experience. Check attached video.

https://github.com/KraXen72/obsidian-emoji-autocomplete/assets/88776039/6e2d62f9-e4d9-4b17-bbcd-9a10e1496e1f